### PR TITLE
rollover: print + sort by resource utilization per instance

### DIFF
--- a/src/rollover.py
+++ b/src/rollover.py
@@ -93,7 +93,7 @@ def prompt_for_instances(ecs_instances, asg_contents, scale_down=False, sort_by=
         utilization = dict(key=lambda i: i.cpu_utilized + i.mem_utilized, reverse=True),
         launch_time = dict(key=lambda i: i.launch_time, reverse=False),
     )
-    sort_type = sorts["utilization"] if sort_by.startswith("util") else sorts["launch_time"]
+    sort_type = sorts[sort_by]
     for x, instance in enumerate(sorted(ecs_instances, key=sort_type["key"], reverse=sort_type["reverse"])):
         print "%d\t - %s" % (x, instance)
     selections = raw_input('Specify the indices - comma-separated (ex. "1,2,4") or inclusive range (ex. "7-11"): ').split(',')
@@ -422,7 +422,7 @@ def main():
                                  help="`docker stop` timeout")
     rollover_parser.add_argument('-s',
                                  '--sort',
-                                 type=str,
+                                 choices=['launch_time', 'utilization'],
                                  default="launch_time",
                                  help="sorts instances by 'launch_time' or 'utilization'. "
                                         "If not provided, defaults to 'launch_time'")
@@ -449,7 +449,7 @@ def main():
                                   help="`docker stop` timeout")
     scaledown_parser.add_argument('-s',
                                  '--sort',
-                                 type=str,
+                                 choices=['launch_time', 'utilization'],
                                  default="launch_time",
                                  help="sorts instances by 'launch_time' or 'utilization'. "
                                         "If not provided, defaults to 'launch_time'")


### PR DESCRIPTION
we sort by the sum of CPU and memory used, as a rough approximation. it
finds instances with poor overall utilization.

Example output:

_sorted by launch_time_

```
...
75       - 48f950af-2bdc-40bc-80ec-aec95db76e73 (i-ea2deb7d - us-west-1b) [ 92% cpu,  85% mem] -- 2016-06-01 23:47:22+00:00
76       - c0f1d530-5a9a-408d-a52d-8b22942e1d9e (i-864d2833 - us-west-1a) [ 42% cpu,  27% mem] -- 2016-06-01 23:47:22+00:00
77       - 65d9e110-4739-4840-a28d-be7fe9651738 (i-b62aec21 - us-west-1b) [ 98% cpu,  68% mem] -- 2016-06-01 23:47:53+00:00
78       - a7b0ce72-7679-44a3-9363-782a93518e1d (i-8e4d283b - us-west-1a) [ 60% cpu,  41% mem] -- 2016-06-01 23:47:53+00:00
```

_sorted by utilization_

```
...
75       - 9a27334e-fe24-4966-8b78-a91e04a629ec (i-c57be670 - us-west-1a) [ 16% cpu,  11% mem] -- 2016-05-26 00:04:47+00:00
76       - ec7a2318-c4fa-42a0-9197-35b1f3a70613 (i-ccca4579 - us-west-1a) [ 13% cpu,  12% mem] -- 2016-05-13 22:58:29+00:00
77       - f244d122-51b7-4bc1-b86e-98442a302601 (i-fb018a4e - us-west-1a) [ 10% cpu,   6% mem] -- 2016-05-18 01:31:49+00:00
78       - fff536df-c906-4c0e-9389-e34bddec7b37 (i-c77be672 - us-west-1a) [ 10% cpu,   6% mem] -- 2016-05-26 00:04:47+00:00
```
