### PR TITLE
Add 'check-task' command

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -30,3 +30,10 @@ def pull_service_id(arn):
     pulls the ecs service id from the full arn
     """
     return arn.split('service/', 1)[-1]
+
+
+def pull_task_definition_name(arn):
+    """
+    pulls the ecs task definition name from the full arn
+    """
+    return arn.split('task-definition/', 1)[-1]


### PR DESCRIPTION
When rolling over, we may want to schedule machines with certain tasks first or last, but we need a way to look up the machine running each task. This command gives us a very basic ability to print ECS instances that are running or not running a given task.

This could also be useful beyond just rollover, so maybe we want a separate tool at some point?
