### PR TITLE
Log ip and add requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 boto3 == 1.3.1
 paramiko == 2.0.0
+six == 1.10.0
+python-dateutil == 2.5.3

--- a/src/rollover.py
+++ b/src/rollover.py
@@ -77,7 +77,7 @@ class ECSInstance(object):
         return cmp(self.ecs_id, other.ecs_id)
 
     def __repr__(self):
-        return "{} ({} - {}) [{:3.0f}% cpu, {:3.0f}% mem] -- {}".format(self.ecs_id, self.ec2_id, self.availability_zone, self.cpu_utilized, self.mem_utilized, self.launch_time)
+        return "{} ({} - {} - {}) [{:3.0f}% cpu, {:3.0f}% mem] -- {}".format(self.ecs_id, self.ec2_id, self.ip_address, self.availability_zone, self.cpu_utilized, self.mem_utilized, self.launch_time)
 
 
 def prompt_for_instances(ecs_instances, asg_contents, scale_down=False, sort_by="launch_time"):


### PR DESCRIPTION
I needed to install six and python-dateutil before i was able to get these scripts running.
Logging IP addresses will also help with finding disconnected instances (because logs from disconnected instances log ip address)
