### PR TITLE
build docker image without USER in name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: build run
 
-
 build:
-	docker build -t ${USER}/ecs-rollover:local .
+	docker build -t ecs-rollover:local .
 

--- a/rollover.sh
+++ b/rollover.sh
@@ -4,4 +4,4 @@ docker run -it \
     -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
     -e AWS_REGION=$AWS_REGION \
-    $USER/ecs-rollover:local $@
+    ecs-rollover:local $@


### PR DESCRIPTION
fails if user has capital letters in name. removing this namespace
should be safe