### PR TITLE
Dockerfile: include src/alb.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY src/__init__.py /opt/ecs-rollover/
 COPY src/ec2.py /opt/ecs-rollover/
 COPY src/ecs.py /opt/ecs-rollover/
 COPY src/elb.py /opt/ecs-rollover/
+COPY src/alb.py /opt/ecs-rollover/
 COPY src/rollover.py /opt/ecs-rollover/
 COPY src/scaling.py /opt/ecs-rollover/
 COPY src/utils.py /opt/ecs-rollover/


### PR DESCRIPTION
Previously:

```
./rollover.sh scaledown CLUSTER ASG
Warning: AWS_REGION is not set. Defaulting to 'us-west-1'
Traceback (most recent call last):
  File "/opt/ecs-rollover/rollover.py", line 15, in <module>
    import alb
ImportError: No module named alb
```