### PR TITLE
Removed unneeded "Install awscli for ECR publish" command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,3 @@ jobs:
         command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
         name: Set up CircleCI artifacts directories
     - run: echo "no tests"
-    - run: $HOME/ci-scripts/circleci/report-card $RC_DOCKER_USER $RC_DOCKER_PASS "$RC_DOCKER_EMAIL" $RC_GITHUB_TOKEN
-    - run:
-        command: |-
-          rm -rf ~/.local
-          cd /tmp/ && wget https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
-          sudo apt-get update
-          sudo apt-get install python-dev
-          sudo pip install --upgrade awscli
-          aws --version
-        name: Install awscli for ECR publish


### PR DESCRIPTION
## This an automated PR
*Risk rating*: low :cat:

Individual circle-ci commands now install the awscli automatically.

Also removed deprecated report-card commands.

Context:
- https://clever.atlassian.net/browse/INFRA-3343
